### PR TITLE
Use Net::HTTP instead of TCPSocket for delivering request

### DIFF
--- a/lib/km.rb
+++ b/lib/km.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'socket'
+require 'net/http'
 require 'fileutils'
 require 'km/saas'
 
@@ -218,14 +219,11 @@ class KM
         log_sent(line)
         return
       end
-      host,port = @host.split(':')
       begin
-        sock = TCPSocket.open(host,port)
-        request = 'GET ' +  line + " HTTP/1.1\r\n"
-        request += "Host: " + Socket.gethostname + "\r\n"
-        request += "Connection: Close\r\n\r\n";
-        sock.print(request)
-        sock.close
+        host,port = @host.split(':')
+        res = Net::HTTP.start(host, port) do |http|
+          http.get(line)
+        end
       rescue Exception => e
         raise KMError.new("#{e} for host #{@host}")
       end


### PR DESCRIPTION
Hello,

I'm using the km gem in an application for delivering events that occur outside of the end-user request/response cycle like monthly billing.  I want to integration test this using Webmock, which relies on the HTTP request being delivered with an HTTP library (Net::HTTP, Patron, Curb, etc.).

This commit changes the KM class to deliver events with Net::HTTP instead of TCPSocket.  The test suite still passes, and there should be no change to the publicly exposed API.  Would you consider including this and issuing a gem release?

Thanks,
Jason
