### PR TITLE
Added proxy support

### DIFF
--- a/lib/km.rb
+++ b/lib/km.rb
@@ -214,7 +214,8 @@ class KM
       end
       begin
         host,port = @host.split(':')
-        res = Net::HTTP.start(host, port) do |http|
+        proxy = URI.parse(ENV['http_proxy'] || ENV['HTTP_PROXY'] || '')
+        res = Net::HTTP::Proxy(proxy.host, proxy.port, proxy.user, proxy.password).start(host, port) do |http|
           http.get(line)
         end
       rescue Exception => e


### PR DESCRIPTION
Hi,

I have added proxy support to this gem, which is now usable behind a corporate firewall.

It now picks up the proxy settings from the standard environment variables `http_proxy` or `HTTP_PROXY`.

`Net::HTTP::Proxy` returns `Net::HTTP` when the proxy host is `nil` so the new code will fallback gracefully when neither of the two variables is set.

The corresponding commit is on the topic branch `proxy_support`.

Thanks,
_Luca Bernardo Ciddio_
