### PR TITLE
Allow km_send to send events for other environments than production

### DIFF
--- a/bin/km_send
+++ b/bin/km_send
@@ -4,11 +4,17 @@ require 'optparse'
 require 'km'
 
 env = 'production'
+force = false
 begin
   parser = OptionParser.new()
   parser.banner = "#{File.basename($0)} [<log_dir>]\n\n"
+
+  parser.on("-f", "--force", "Force sending the data to KM, ignoring the environment.") do |e|
+    force = true
+  end
+
   parser.on("-e", "--env ENVIRONMENT", "The environment to run in. Default: production") do |e|
-    puts "Note, only production will actually send queries to the kissmetrics servers."
+    puts "Note, only production will actually send queries to the kissmetrics servers unless the --force flag is used." unless force
     env = e
   end
 
@@ -24,5 +30,6 @@ rescue => e
   exit(-1)
 end
 
-KM.init('', :log_dir => opts[0] || KM.log_dir, :host => opts[1] || KM.host, :env => env)
+
+KM.init('', :log_dir => opts[0] || KM.log_dir, :host => opts[1] || KM.host, :force => force, :env => env)
 KM.send_logged_queries

--- a/spec/km_send_spec.rb
+++ b/spec/km_send_spec.rb
@@ -11,11 +11,82 @@ describe 'km_send' do
       KM.reset
       Helper.clear
     end
-    it "should test commandline version" do
-      KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true
+    context "with default environment" do
+      before do
+        KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true
+      end
+      it "should test commandline version" do
+        KM::identify 'bob'
+        KM::record 'Signup', 'age' => 26
+        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.indifferent
+        res[:path].should == '/e'
+        res[:query]['_k'].first.should == 'KM_KEY'
+        res[:query]['_p'].first.should == 'bob'
+        res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_t'].first.should == Time.now.to_i.to_s
+        res[:query]['age'].first.should == '26'
+      end
+      it "should send from query_log" do
+        write_log :query, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
+        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.indifferent
+        res[:path].should == '/e'
+        res[:query]['_k'].first.should == 'KM_KEY'
+        res[:query]['_p'].first.should == 'bob'
+        res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_t'].first.should == '1297105499'
+        res[:query]['age'].first.should == '26'
+      end
+      it "should send from query_log_old" do
+        write_log :query_old, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
+        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.indifferent
+        res[:path].should == '/e'
+        res[:query]['_k'].first.should == 'KM_KEY'
+        res[:query]['_p'].first.should == 'bob'
+        res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_t'].first.should == '1297105499'
+        res[:query]['age'].first.should == '26'
+      end
+      it "should send from both query_log and query_log_old" do
+        File.open(__('log/kissmetrics_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=27" }
+        File.open(__('log/kissmetrics_production_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
+        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.indifferent
+        res[:path].should == '/e'
+        res[:query]['_k'].first.should == 'KM_KEY'
+        res[:query]['_p'].first.should == 'bob'
+        res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_t'].first.should == '1297105499'
+        res[:query]['age'].first.should == '27'
+        Helper.clear
+        `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.indifferent
+        res[:path].should == '/e'
+        res[:query]['_k'].first.should == 'KM_KEY'
+        res[:query]['_p'].first.should == 'bob'
+        res[:query]['_n'].first.should == 'Signup'
+        res[:query]['_t'].first.should == '1297105499'
+        res[:query]['age'].first.should == '26'
+      end
+      it "should not send from diff environment as we only send when env is production" do
+        File.open(__('log/kissmetrics_alpha_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
+        `bundle exec km_send -e alpha #{__('log/')} 127.0.0.1:9292`
+        sleep 0.1
+        res = Helper.accept(:history).first.should == nil
+      end
+    end
+    it "should send from diff environment when force flag is used" do
+      KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true, :env => 'development', :force => true
       KM::identify 'bob'
       KM::record 'Signup', 'age' => 26
-      `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
+      `bundle exec km_send -f -e development #{__('log/')} 127.0.0.1:9292`
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
@@ -24,59 +95,6 @@ describe 'km_send' do
       res[:query]['_n'].first.should == 'Signup'
       res[:query]['_t'].first.should == Time.now.to_i.to_s
       res[:query]['age'].first.should == '26'
-    end
-    it "should send from query_log" do
-      write_log :query, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
-      `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
-      sleep 0.1
-      res = Helper.accept(:history).first.indifferent
-      res[:path].should == '/e'
-      res[:query]['_k'].first.should == 'KM_KEY'
-      res[:query]['_p'].first.should == 'bob'
-      res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == '1297105499'
-      res[:query]['age'].first.should == '26'
-    end
-    it "should send from query_log_old" do
-      write_log :query_old, "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26"
-      `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
-      sleep 0.1
-      res = Helper.accept(:history).first.indifferent
-      res[:path].should == '/e'
-      res[:query]['_k'].first.should == 'KM_KEY'
-      res[:query]['_p'].first.should == 'bob'
-      res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == '1297105499'
-      res[:query]['age'].first.should == '26'
-    end
-    it "should send from both query_log and query_log_old" do
-      File.open(__('log/kissmetrics_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=27" }
-      File.open(__('log/kissmetrics_production_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
-      `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
-      sleep 0.1
-      res = Helper.accept(:history).first.indifferent
-      res[:path].should == '/e'
-      res[:query]['_k'].first.should == 'KM_KEY'
-      res[:query]['_p'].first.should == 'bob'
-      res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == '1297105499'
-      res[:query]['age'].first.should == '27'
-      Helper.clear
-      `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
-      sleep 0.1
-      res = Helper.accept(:history).first.indifferent
-      res[:path].should == '/e'
-      res[:query]['_k'].first.should == 'KM_KEY'
-      res[:query]['_p'].first.should == 'bob'
-      res[:query]['_n'].first.should == 'Signup'
-      res[:query]['_t'].first.should == '1297105499'
-      res[:query]['age'].first.should == '26'
-    end
-    it "should not send from diff environment as we only send when env is production" do
-      File.open(__('log/kissmetrics_alpha_query.log'), 'w+') { |h| h.puts "/e?_t=1297105499&_n=Signup&_p=bob&_k=KM_KEY&age=26" }
-      `bundle exec km_send -e alpha #{__('log/')} 127.0.0.1:9292`
-      sleep 0.1
-      res = Helper.accept(:history).first.should == nil
     end
   end
 end

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -175,7 +175,6 @@ describe KM do
       File.exists?(__('log/kissmetrics_production_query.log')).should == true
       File.exists?(__('log/kissmetrics_production_error.log')).should == true
     end
-
     it "should escape @ properly" do
       KM::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292', :to_stderr => false, :use_cron => true
       KM::identify 'bob'


### PR DESCRIPTION
We need to test our server side events on the development / staging server before the changes go in production. There is a hard coded check that prevents sending events for other environments than production. I added a --force flag on km_send that allows skipping this check.

```
bundle exec km_send --force
```
