### PR TITLE
Make KM reasonably threadsafe

### DIFF
--- a/lib/km.rb
+++ b/lib/km.rb
@@ -7,7 +7,6 @@ require 'km/saas'
 class KMError < StandardError; end
 
 class KM
-  @id        = nil
   @key       = nil
   @logs      = {}
   @host      = 'trk.kissmetrics.com:80'
@@ -51,18 +50,14 @@ class KM
       @env ||= 'production'
     end
 
-    def identify(id)
-      @id = id
-    end
-
-    def record(action,props={})
+    def record(id, action, props={})
       props = hash_keys_to_str(props)
       begin
-        return unless is_initialized_and_identified?
-        return set(action) if action.class == Hash
+        return unless is_initialized?
+        return set(id, action) if action.class == Hash
 
         props.update('_n' => action)
-        generate_query('e', props)
+        generate_query('e', props, id)
       rescue Exception => e
         log_error(e)
       end
@@ -77,10 +72,10 @@ class KM
       end
     end
 
-    def set(data)
+    def set(id, data)
       begin
-        return unless is_initialized_and_identified?
-        generate_query('s', data)
+        return unless is_initialized?
+        generate_query('s', data, id)
       rescue Exception => e
         log_error(e)
       end
@@ -178,6 +173,7 @@ class KM
     def log(type,msg)
       begin
         File.open(log_name(type), 'a') do |fh|
+          fh.flock(File::LOCK_EX)
           fh.puts(msg)
         end
       rescue Exception => e
@@ -187,11 +183,11 @@ class KM
     end
 
 
-    def generate_query(type, data, update=true)
+    def generate_query(type, data, id = nil)
       data = hash_keys_to_str(data)
       query_arr = []
       query     = ''
-      data.update('_p' => @id) unless update == false
+      data.update('_p' => id) if id
       data.update('_k' => @key)
       data.update '_d' => 1 if data['_t']
       data['_t'] ||= Time.now.to_i

--- a/lib/km/saas.rb
+++ b/lib/km/saas.rb
@@ -1,37 +1,37 @@
 require 'km'
 class KM
   module SaaS
-    def signed_up(plan=nil, props = {})
+    def signed_up(id, plan=nil, props = {})
       props['Plan Name'] = plan unless plan.to_s.empty?
-      record 'Signed Up', props
+      record id, 'Signed Up', props
     end
     alias signedup signed_up
 
-    def upgraded(plan=nil, props = {})
+    def upgraded(id, plan=nil, props = {})
       props['Plan Name'] = plan unless plan.to_s.empty?
-      record 'Upgraded', props
+      record id, 'Upgraded', props
     end
 
-    def downgraded(plan=nil, props = {})
+    def downgraded(id, plan=nil, props = {})
       props['Plan Name'] = plan unless plan.to_s.empty?
-      record 'Downgraded', props
+      record id, 'Downgraded', props
     end
 
-    def billed(amount=nil, description=nil, props={})
+    def billed(id, amount=nil, description=nil, props={})
       props['Billing Amount']      = amount unless amount.to_s.empty?
       props['Billing Description'] = description unless description.to_s.empty?
-      record 'Billed', props
+      record id, 'Billed', props
     end
 
-    def canceled(props={})
-      record 'Canceled', props
+    def canceled(id, props={})
+      record id, 'Canceled', props
     end
     alias cancelled canceled
 
-    def visited_site(url=nil, referrer=nil, props={})
+    def visited_site(id, url=nil, referrer=nil, props={})
       props['URL']      = url unless url.to_s.empty?
       props['Referrer'] = referrer unless referrer.to_s.empty?
-      record 'Visited Site', props
+      record id, 'Visited Site', props
     end
     # ------------------------------------------------------------------------
   end

--- a/spec/km_saas_spec.rb
+++ b/spec/km_saas_spec.rb
@@ -13,11 +13,10 @@ describe KM do
   describe "should record events" do
     before do
       KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292'
-      KM::identify 'bob'
     end
     context "plain usage" do
       it "records a signup event" do
-        KM.signed_up 'Premium'
+        KM.signed_up 'bob', 'Premium'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -25,7 +24,7 @@ describe KM do
         res[:query]['Plan Name'].first.should == 'Premium'
       end
       it "records an upgraded event" do
-        KM.upgraded 'Unlimited'
+        KM.upgraded 'bob', 'Unlimited'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -33,7 +32,7 @@ describe KM do
         res[:query]['Plan Name'].first.should == 'Unlimited'
       end
       it "records a downgraded event" do
-        KM.downgraded 'Free'
+        KM.downgraded 'bob', 'Free'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -41,7 +40,7 @@ describe KM do
         res[:query]['Plan Name'].first.should == 'Free'
       end
       it "records a billed event" do
-        KM.billed 32, 'Upgraded'
+        KM.billed 'bob', 32, 'Upgraded'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -50,21 +49,14 @@ describe KM do
         res[:query]['Billing Description'].first.should == 'Upgraded'
       end
       it "records a canceled event" do
-        KM.canceled
-        sleep 0.1
-        res = Helper.accept(:history).first.indifferent
-        res[:path].should == '/e'
-        res[:query]['_n'].first.should == 'Canceled'
-      end
-      it "records a cancelled event" do
-        KM.cancelled
+        KM.canceled 'bob'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
         res[:query]['_n'].first.should == 'Canceled'
       end
       it "records a visited site event" do
-        KM.visited_site 'http://duckduckgo.com', 'http://kissmetrics.com'
+        KM.visited_site 'bob', 'http://duckduckgo.com', 'http://kissmetrics.com'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:path].should == '/e'
@@ -75,43 +67,37 @@ describe KM do
     end
     context "usage with props" do
       it "records a signup event" do
-        KM.signed_up 'Premium', :foo => 'bar'
+        KM.signed_up 'bob', 'Premium', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'
       end
       it "records an upgraded event" do
-        KM.upgraded 'Unlimited', :foo => 'bar'
+        KM.upgraded 'bob', 'Unlimited', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'
       end
       it "records a downgraded event" do
-        KM.downgraded 'Free', :foo => 'bar'
+        KM.downgraded 'bob', 'Free', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'
       end
       it "records a billed event" do
-        KM.billed 32, 'Upgraded', :foo => 'bar'
+        KM.billed 'bob', 32, 'Upgraded', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'
       end
       it "records a canceled event" do
-        KM.canceled :foo => 'bar'
-        sleep 0.1
-        res = Helper.accept(:history).first.indifferent
-        res[:query]['foo'].first.should == 'bar'
-      end
-      it "records a cancelled event" do
-        KM.cancelled :foo => 'bar'
+        KM.canceled 'bob', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'
       end
       it "records a visited site event" do
-        KM.visited_site 'http://duckduckgo.com', 'http://kissmetrics.com', :foo => 'bar'
+        KM.visited_site 'bob', 'http://duckduckgo.com', 'http://kissmetrics.com', :foo => 'bar'
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
         res[:query]['foo'].first.should == 'bar'

--- a/spec/km_send_spec.rb
+++ b/spec/km_send_spec.rb
@@ -16,8 +16,7 @@ describe 'km_send' do
         KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true
       end
       it "should test commandline version" do
-        KM::identify 'bob'
-        KM::record 'Signup', 'age' => 26
+        KM::record 'bob', 'Signup', 'age' => 26
         `bundle exec km_send #{__('log/')} 127.0.0.1:9292`
         sleep 0.1
         res = Helper.accept(:history).first.indifferent
@@ -84,8 +83,7 @@ describe 'km_send' do
     end
     it "should send from diff environment when force flag is used" do
       KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292', :use_cron => true, :env => 'development', :force => true
-      KM::identify 'bob'
-      KM::record 'Signup', 'age' => 26
+      KM::record 'bob', 'Signup', 'age' => 26
       `bundle exec km_send -f -e development #{__('log/')} 127.0.0.1:9292`
       sleep 0.1
       res = Helper.accept(:history).first.indifferent

--- a/spec/km_spec.rb
+++ b/spec/km_spec.rb
@@ -8,22 +8,14 @@ describe KM do
     FileUtils.rm_f KM::log_name(:query)
     Helper.clear
   end
-  it "shouldn't write at all without init or identify" do
-    KM::record 'My Action'
+
+  it "shouldn't write at all without init" do
+    KM::record 'my_id', 'My Action'
     IO.readlines(KM::log_name(:error)).join.should =~ /Need to initialize first \(KM::init <your_key>\)/
 
     FileUtils.rm_f KM::log_name(:error)
-    KM::set :day => 'friday'
+    KM::set 'my_id', :day => 'friday'
     IO.readlines(KM::log_name(:error)).join.should =~ /Need to initialize first \(KM::init <your_key>\)/
-
-    KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292'
-    FileUtils.rm_f KM::log_name(:error)
-    KM::record 'My Action'
-    IO.readlines(KM::log_name(:error)).last.should =~ /Need to identify first \(KM::identify <user>\)/
-
-    FileUtils.rm_f KM::log_name(:error)
-    KM::set :day => 'friday'
-    IO.readlines(KM::log_name(:error)).last.should =~ /Need to identify first \(KM::identify <user>\)/
   end
 
   it "shouldn't fail on alias without identifying" do
@@ -37,6 +29,7 @@ describe KM do
     res[:query]['_n'].first.should == 'joe'
     res[:query]['_t'].first.should == Time.now.to_i.to_s
   end
+
   it "shouldn't fail on alias without identifying from commandline" do
     KM::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292'
     KM::alias 'peter','joe' # Alias "bob" to "robert"
@@ -52,10 +45,9 @@ describe KM do
   describe "should record events" do
     before do
       KM::init 'KM_KEY', :log_dir => __('log'), :host => '127.0.0.1:9292'
-      KM::identify 'bob'
     end
     it "records an action with no action-specific properties" do
-      KM::record 'My Action'
+      KM::record 'bob', 'My Action'
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
@@ -65,7 +57,7 @@ describe KM do
       res[:query]['_t'].first.should == Time.now.to_i.to_s
     end
     it "records an action with properties" do
-      KM::record 'Signup', 'age' => 26
+      KM::record 'bob', 'Signup', 'age' => 26
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
@@ -76,7 +68,7 @@ describe KM do
       res[:query]['age'].first.should == 26.to_s
     end
     it "should be able to hace spaces in key and value" do
-      KM::record 'Signup', 'age' => 26, 'city of residence' => 'eug ene'
+      KM::record 'bob', 'Signup', 'age' => 26, 'city of residence' => 'eug ene'
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
@@ -88,7 +80,7 @@ describe KM do
       res[:query]['city of residence'].first.should == 'eug ene'
     end
     it "should not override important parts" do
-      KM::record 'Signup', 'age' => 26, '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else'
+      KM::record 'bob', 'Signup', 'age' => 26, '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else'
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
@@ -99,7 +91,7 @@ describe KM do
       res[:query]['age'].first.should == 26.to_s
     end
     it "should work with propps using @" do
-      KM::record 'Signup', 'email' => 'test@blah.com', '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else'
+      KM::record 'bob', 'Signup', 'email' => 'test@blah.com', '_p' => 'billybob', '_k' => 'foo', '_n' => 'something else'
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/e'
       res[:query]['_k'].first.should == 'KM_KEY'
@@ -109,7 +101,7 @@ describe KM do
       res[:query]['email'].first.should == 'test@blah.com'
     end
     it "should just set properties without event" do
-      KM::record 'age' => 26
+      KM::record 'bob', 'age' => 26
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/s'
@@ -119,7 +111,7 @@ describe KM do
       res[:query]['age'].first.should == 26.to_s
     end
     it "should be able to use km set directly" do
-      KM::set 'age' => 26
+      KM::set 'bob', 'age' => 26
       sleep 0.1
       res = Helper.accept(:history).first.indifferent
       res[:path].should == '/s'
@@ -130,9 +122,9 @@ describe KM do
     end
     it "should work with multiple lines" do
       # testing recording of multiple lines.
-      KM::record 'Signup', 'age' => 26
+      KM::record 'bob', 'Signup', 'age' => 26
       sleep 0.1
-      KM::record 'Signup', 'age' => 36
+      KM::record 'bob', 'Signup', 'age' => 36
       sleep 0.1
       res = Helper.accept(:history)[0].indifferent
       res[:path].should == '/e'
@@ -169,16 +161,14 @@ describe KM do
     end
     it "should run fine even though there's no server to connect to" do
       KM::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9291', :to_stderr => false
-      KM::identify 'bob'
-      KM::record 'My Action' # records an action with no action-specific properties;
+      KM::record 'bob', 'My Action' # records an action with no action-specific properties;
       Helper.accept(:history).size.should == 0
       File.exists?(__('log/kissmetrics_production_query.log')).should == true
       File.exists?(__('log/kissmetrics_production_error.log')).should == true
     end
     it "should escape @ properly" do
       KM::init 'KM_OTHER', :log_dir => __('log'), :host => '127.0.0.1:9292', :to_stderr => false, :use_cron => true
-      KM::identify 'bob'
-      KM::record 'prop_with_@_in' # records an action with no action-specific properties;
+      KM::record 'bob', 'prop_with_@_in' # records an action with no action-specific properties;
       IO.readlines(KM::log_name(:query)).join.should_not contain_string('@')
     end
   end


### PR DESCRIPTION
Note: I don't really expect this pull request to be merged, but I'd like to let people know this fork exists, and to receive some feedback. 

This fork removes most global state from the KM class, making it safer to use in multithreaded servers (most JRuby servers, plus puma, thin and soon passenger 4). The main offender is the globally stored user identity, so that's what I've focused on. Original commit message follows below.

---

WARNING: This is a backwards incompatible change. The 'identify'
method is gone, and all methods that previously used the globbaly set
identity now require it to be passed before other arguments. So:

KM::record(action, props) -> KM::record(identity, action, props)
KM::set(data) -> KM::set(identity, data)

KM::alias doesn't require the identity to be set, and keeps the same
signature as before. Internal methods (i.e., generate_query) were
updated accordingly.

Other internal changes include file locking when writing to the query
log file, and copying and truncating (with locks) instead of moving
when processing the log file for sending.
