### PR TITLE
By default, push events to tracking servers, even when :env=development

### DIFF
--- a/lib/km.rb
+++ b/lib/km.rb
@@ -14,7 +14,7 @@ class KM
   @log_dir   = '/tmp'
   @to_stderr = true
   @use_cron  = false
-  @force     = false
+  @dryrun    = false
 
   class << self
     class IdentError < StandardError; end
@@ -26,7 +26,7 @@ class KM
         :log_dir   => @log_dir,
         :to_stderr => @to_stderr,
         :use_cron  => @use_cron,
-        :force     => @force,
+        :dryrun    => @dryrun,
         :env       => set_env,
       }
       options = default.merge(options)
@@ -37,7 +37,7 @@ class KM
         @log_dir   = options[:log_dir]
         @use_cron  = options[:use_cron]
         @to_stderr = options[:to_stderr]
-        @force     = options[:force]
+        @dryrun    = options[:dryrun]
         @env       = options[:env]
         log_dir_writable?
       rescue Exception => e
@@ -215,7 +215,9 @@ class KM
     end
 
     def send_query(line)
-      if @force || @env == 'production'
+      if @dryrun
+        log_sent(line)
+      else
         begin
           host,port = @host.split(':')
           proxy = URI.parse(ENV['http_proxy'] || ENV['HTTP_PROXY'] || '')
@@ -226,9 +228,6 @@ class KM
           raise KMError.new("#{e} for host #{@host}")
         end
         log_sent(line)
-      else
-        log_sent(line)
-        return
       end
     end
 


### PR DESCRIPTION
We've gotten enough feedback suggesting that working in :env=development should
work out of the box, without any hidden 'gotchas' that it just logs your
queries to a file. Developers should be smart enough to use a Dev API key if
they're initializing KM with :env=development, and so just want to see whether
the data enters KM.

So with the :dryrun option, the logic goes:
1. If you really want a dry-run, then just log that the events happen and
   nothing else
2. In any other scenario (dev or production environment equally), process and
   send the events to trk.kissmetrics.com
