### PR TITLE
Adding _d to all generated requests.

### DIFF
--- a/lib/km.rb
+++ b/lib/km.rb
@@ -193,7 +193,7 @@ class KM
       query     = ''
       data.update('_p' => @id) unless update == false
       data.update('_k' => @key)
-      data.update '_d' => 1 if data['_t']
+      data.update '_d' => 1
       data['_t'] ||= Time.now.to_i
       
       unsafe = Regexp.new("[^#{URI::REGEXP::PATTERN::UNRESERVED}]", false, 'N')


### PR DESCRIPTION
Always setting _d=1. Otherwise, if you are logging events and waiting on cron to submit the events, the generated queries don't include _d and the events will be pegged at the time the cronjob executes, not when the event happens.
